### PR TITLE
Release 3.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - if: matrix.symfony == '5.4.*'
         run: |
-          sed -ri 's/"symfony\/framework-bundle": "(.+)"/"symfony\/framework-bundle": "${{ matrix.symfony }}"/' composer.json; &&
+          sed -ri 's/"symfony\/framework-bundle": "(.+)"/"symfony\/framework-bundle": "${{ matrix.symfony }}"/' composer.json;
           sed -ri 's/"symfony\/yaml": "(.+)"/"symfony\/yaml": "${{ matrix.symfony }}"/' composer.json;
       - if: matrix.symfony != '5.4.*'
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,23 +24,13 @@ jobs:
         run: composer install
       - name: CS Check
         run: composer cs-check
-
   tests:
+    name: PHP ${{ matrix.php }} / SF ^${{ matrix.symfony }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name:
-          - 'PHP 8.0 tests (Symfony 5.4)'
-          - 'PHP 8.1 tests (Symfony 6.2)'
-          - 'PHP 8.1 tests (Symfony 6.3)'
-        include:
-          - php: '8.0'
-            symfony: 5.4.*
-          - php: '8.1'
-            symfony: 6.2.*
-          - php: '8.1'
-            symfony: 6.3.*
-    name: ${{ matrix.name }}
+        php: ['8.1']
+        symfony: ['5.4.*', '6.2.*', '6.3.*']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,8 @@ jobs:
           php-version: ${{ matrix.php }}
       - if: matrix.symfony == '5.4.*'
         run: |
-          sed -ri 's/"symfony\/(?:clock)(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
+          sed -ri 's/"symfony\/framework-bundle": "(.+)"/"symfony\/framework-bundle": "${{ matrix.symfony }}"/' composer.json; &&
+          sed -ri 's/"symfony\/yaml": "(.+)"/"symfony\/yaml": "${{ matrix.symfony }}"/' composer.json;
       - if: matrix.symfony != '5.4.*'
         run: |
           sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,8 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1']
+        php: ['8.1','8.2']
         symfony: ['5.4.*', '6.2.*', '6.3.*']
+        exclude:
+          - php: '8.2'
+            symfony: '5.4.*'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - if: matrix.symfony == '5.4.*'
         run: |
-          sed -ri 's/"symfony\/(?!clock)(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
+          sed -ri 's/"symfony\/(?:clock)(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
       - if: matrix.symfony != '5.4.*'
         run: |
           sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,8 +43,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-      - run: |
+      - if: matrix.symfony == '5.4.*'
+        run: |
+          sed -ri 's/"symfony\/(?!clock")(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
+      - if: matrix.symfony != '5.4.*'
+        run: |
           sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
-        if: matrix.symfony
       - run: composer update --no-interaction --no-progress --ansi
       - run: composer phpunit

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - if: matrix.symfony == '5.4.*'
         run: |
-          sed -ri 's/"symfony\/(?!clock")(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
+          sed -ri 's/"symfony\/(?!clock)(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;
       - if: matrix.symfony != '5.4.*'
         run: |
           sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "${{ matrix.symfony }}"/' composer.json;

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/framework-bundle": "^5.0 | ^6.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.2 | ^2.0",
-        "symfony/clock": "^6.3"
+        "symfony/clock": "^6.2"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,11 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "symfony/framework-bundle": "^5.0 | ^6.0",
         "doctrine/common": "^2.13 || ^3.0",
-        "doctrine/event-manager": "^1.2 | ^2.0"
+        "doctrine/event-manager": "^1.2 | ^2.0",
+        "symfony/clock": "^6.3"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/DependencyInjection/Compiler/DoctrineEventSubscriberPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineEventSubscriberPass.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Andante\TimestampableBundle\DependencyInjection\Compiler;
 
 use Andante\TimestampableBundle\EventSubscriber\TimestampableEventSubscriber;
+use Composer\InstalledVersions;
+use Doctrine\ORM\Events;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -12,15 +16,37 @@ use Symfony\Component\DependencyInjection\Reference;
 class DoctrineEventSubscriberPass implements CompilerPassInterface
 {
     public const TIMESTAMPABLE_SUBSCRIBER_SERVICE_ID = 'andante_timestampable.doctrine.timestampable_subscriber';
+    public const CLOCK_SERVICE_ID = 'andante_timestampable.clock';
 
     public function process(ContainerBuilder $container): void
     {
-        $container
+        $subscriberDefinition = $container
             ->register(
                 self::TIMESTAMPABLE_SUBSCRIBER_SERVICE_ID,
                 TimestampableEventSubscriber::class
             )
             ->addArgument(new Reference('andante_timestampable.configuration'))
             ->addTag('doctrine.event_subscriber');
+        $symfonyDoctrineBridgeVersion = InstalledVersions::getVersion('symfony/doctrine-bridge');
+        if (null !== $symfonyDoctrineBridgeVersion && \version_compare($symfonyDoctrineBridgeVersion, '6.3', '>=')) {
+            $subscriberDefinition->addTag('doctrine.event_listener', [
+                'event' => Events::prePersist,
+            ]);
+            $subscriberDefinition->addTag('doctrine.event_listener', [
+                'event' => Events::preUpdate,
+            ]);
+            $subscriberDefinition->addTag('doctrine.event_listener', [
+                'event' => Events::loadClassMetadata,
+            ]);
+        } else {
+            $subscriberDefinition->addTag('doctrine.event_subscriber');
+        }
+
+        if ($container->has(ClockInterface::class)) {
+            $subscriberDefinition->addArgument(new Reference(ClockInterface::class));
+        } else {
+            $container->register(self::CLOCK_SERVICE_ID, Clock::class);
+            $subscriberDefinition->addArgument(new Reference(self::CLOCK_SERVICE_ID));
+        }
     }
 }

--- a/src/EventSubscriber/TimestampableEventSubscriber.php
+++ b/src/EventSubscriber/TimestampableEventSubscriber.php
@@ -12,14 +12,19 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Psr\Clock\ClockInterface;
 
 class TimestampableEventSubscriber implements EventSubscriber
 {
     private Configuration $configuration;
+    private ClockInterface $clock;
 
-    public function __construct(Configuration $configuration)
-    {
+    public function __construct(
+        Configuration $configuration,
+        ClockInterface $clock
+    ) {
         $this->configuration = $configuration;
+        $this->clock = $clock;
     }
 
     public function getSubscribedEvents(): array
@@ -35,7 +40,7 @@ class TimestampableEventSubscriber implements EventSubscriber
     {
         $entity = $onFlushEventArgs->getObject();
         if ($entity instanceof CreatedAtTimestampableInterface && null === $entity->getCreatedAt()) {
-            $entity->setCreatedAt(new \DateTimeImmutable());
+            $entity->setCreatedAt($this->clock->now());
         }
     }
 
@@ -43,7 +48,7 @@ class TimestampableEventSubscriber implements EventSubscriber
     {
         $entity = $onFlushEventArgs->getObject();
         if ($entity instanceof UpdatedAtTimestampableInterface) {
-            $entity->setUpdatedAt(new \DateTimeImmutable());
+            $entity->setUpdatedAt($this->clock->now());
         }
     }
 


### PR DESCRIPTION
- Move min version of PHP to 8.1;
- Solve Symfony/doctrine-bridge 6.3 deprecation;
- Use clock component instead of `new \DateTimeImmutable`.