### PR TITLE
update phpstan to 2.0 and fix errors it reports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
         "ext-json": "*",
         "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.2",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-symfony": "^1.0",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-symfony": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.58"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,9 @@
 parameters:
     level: 8
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     excludePaths:
         - src/DependencyInjection/Configuration.php
+    ignoreErrors:
+        - identifier: property.onlyRead
+          path: tests/Fixtures/Entity/Address.php
+        - identifier: property.onlyRead
+          path: tests/Fixtures/Entity/Organization.php

--- a/src/CacheClearer/TimestampableCacheClearer.php
+++ b/src/CacheClearer/TimestampableCacheClearer.php
@@ -11,7 +11,7 @@ class TimestampableCacheClearer implements CacheClearerInterface
 {
     public const METADATA_CACHE_FILENAME = 'timestampable_metadata.php';
 
-    private ?Filesystem $filesystem;
+    private Filesystem $filesystem;
 
     public function __construct(?Filesystem $filesystem = null)
     {
@@ -20,7 +20,7 @@ class TimestampableCacheClearer implements CacheClearerInterface
 
     public function clear(string $cacheDir): void
     {
-        $filesystem = $this->filesystem ?? new Filesystem();
+        $filesystem = $this->filesystem;
         $metadataFile = $cacheDir.'/'.self::METADATA_CACHE_FILENAME;
         if ($filesystem->exists($metadataFile)) {
             $filesystem->remove($metadataFile);

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -26,6 +26,7 @@ class Configuration
         $this->defaultConfiguration = $defaultConfiguration;
     }
 
+    /** @return array<string, EntityConfiguration> */
     public function getEntitiesConfigurations(): array
     {
         return $this->entitiesConfigurations;
@@ -47,6 +48,7 @@ class Configuration
         return $this;
     }
 
+    /** @param array<string, mixed> $config */
     public static function createFromArray(array $config): self
     {
         $configuration = new self();

--- a/src/Config/EntityConfiguration.php
+++ b/src/Config/EntityConfiguration.php
@@ -54,6 +54,7 @@ class EntityConfiguration
         $this->updatedAtColumnName = $updatedAtColumnName;
     }
 
+    /** @param array<string, mixed> $config */
     public static function createFromArray(array $config, ?EntityConfiguration $fallbackConfig = null): self
     {
         $entityConfiguration = new self();

--- a/src/EventSubscriber/TimestampableEventSubscriber.php
+++ b/src/EventSubscriber/TimestampableEventSubscriber.php
@@ -67,7 +67,7 @@ class TimestampableEventSubscriber implements EventSubscriber
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
 
-        /** @var \ReflectionClass|null $rClass */
+        /** @var \ReflectionClass<object>|null $rClass */
         $rClass = $classMetadata->reflClass;
         if (null === $rClass) {
             return;

--- a/tests/Fixtures/Entity/Address.php
+++ b/tests/Fixtures/Entity/Address.php
@@ -13,7 +13,8 @@ class Address implements TimestampableInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private ?int $id = null;
+    /** @readonly */
+    private int $id;
 
     #[ORM\Column(type: 'string')]
     private ?string $name = null;
@@ -21,7 +22,7 @@ class Address implements TimestampableInterface
     private ?\DateTimeImmutable $created = null;
     private ?\DateTimeImmutable $updated = null;
 
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Fixtures/Entity/Organization.php
+++ b/tests/Fixtures/Entity/Organization.php
@@ -16,12 +16,13 @@ class Organization implements TimestampableInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private ?int $id = null;
+    /** @readonly */
+    private int $id;
 
     #[ORM\Column(type: 'string')]
     private ?string $name = null;
 
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Functional/DependencyInjection/DefaultConfigTest.php
+++ b/tests/Functional/DependencyInjection/DefaultConfigTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class DefaultConfigTest extends KernelTestCase
 {
+    /** @param array<string, mixed> $options */
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TimestampableAppKernel('test', true, [

--- a/tests/Functional/EventSubscriber/MappingTest.php
+++ b/tests/Functional/EventSubscriber/MappingTest.php
@@ -18,6 +18,7 @@ class MappingTest extends KernelTestCase
 {
     use TimestampableConfigTrait;
 
+    /** @param array<string, mixed> $options */
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TimestampableAppKernel('test', true, self::getTimestampableConfig());
@@ -35,7 +36,7 @@ class MappingTest extends KernelTestCase
         self::assertSame(Types::DATETIME_IMMUTABLE, $classMetadata->fieldMappings['createdAt']['type']);
         self::assertSame(Types::DATETIME_IMMUTABLE, $classMetadata->fieldMappings['updatedAt']['type']);
 
-        /** @var ClassMetadata $classMetadata */
+        /** @var ClassMetadata<object> $classMetadata */
         $classMetadata = $em->getClassMetadata(Address::class);
         self::assertArrayHasKey('created', $classMetadata->fieldMappings);
         self::assertArrayHasKey('updated', $classMetadata->fieldMappings);

--- a/tests/Functional/EventSubscriber/SetupTest.php
+++ b/tests/Functional/EventSubscriber/SetupTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class SetupTest extends KernelTestCase
 {
+    /** @param array<string, mixed> $options */
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TimestampableAppKernel('test', true, [

--- a/tests/Functional/EventSubscriber/TimestampableTest.php
+++ b/tests/Functional/EventSubscriber/TimestampableTest.php
@@ -20,6 +20,7 @@ class TimestampableTest extends KernelTestCase
 
     private const SLEEP_BETWEEN_UPDATES_SECONDS = 1;
 
+    /** @param array<string, mixed> $options */
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TimestampableAppKernel('test', true, self::getTimestampableConfig());

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -36,13 +36,14 @@ abstract class FunctionalTestCase extends KernelTestCase
      */
     protected static function getTestContainer(): ContainerInterface
     {
-        if (\method_exists(KernelTestCase::class, 'getContainer')) {
-            return parent::getContainer();
-        }
-        $kernel = static::$kernel;
-        \assert(null !== $kernel, 'Kernel must be booted');
+        if (static::class === KernelTestCase::class) {
+            $kernel = static::$kernel;
+            \assert(null !== $kernel, 'Kernel must be booted');
 
-        return $kernel->getContainer();
+            return $kernel->getContainer();
+        }
+
+        return self::getContainer();
     }
 
     protected function createSchema(): void
@@ -53,7 +54,7 @@ abstract class FunctionalTestCase extends KernelTestCase
         $ems = $manager->getManagers();
         /** @var EntityManagerInterface $em */
         $em = \reset($ems);
-        /** @var array<int, ClassMetadata> $metadatas */
+        /** @var list<ClassMetadata<object>> $metadatas */
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema($metadatas);

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -36,7 +36,7 @@ abstract class FunctionalTestCase extends KernelTestCase
      */
     protected static function getTestContainer(): ContainerInterface
     {
-        if (static::class === KernelTestCase::class) {
+        if (KernelTestCase::class === static::class) {
             $kernel = static::$kernel;
             \assert(null !== $kernel, 'Kernel must be booted');
 

--- a/tests/Functional/Timestampable/RegistryColdPathTest.php
+++ b/tests/Functional/Timestampable/RegistryColdPathTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class RegistryColdPathTest extends KernelTestCase
 {
+    /** @param array<string, mixed> $options */
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TimestampableAppKernel('test', true, [


### PR DESCRIPTION
Updated PHPStan from 1.x to 2.0 and resolved all resulting analysis errors.

Tests pass.  

### Composer Updates
- `phpstan/phpstan`: `^1.2` → `^2.0`
- `phpstan/phpstan-phpunit`: `^1.0` → `^2.0`
- `phpstan/phpstan-symfony`: `^1.0` → `^2.0`
- `phpstan/extension-installer`: kept at `^1.4` (not yet available as 2.0)
### Config Changes
- Removed deprecated PHPStan options from `phpstan.neon`:
  - `checkMissingIterableValueType`
  - `checkGenericClassInNonGenericObjectType`
- Added ignoreError for `property.onlyRead` in test fixtures (Doctrine-managed entity IDs)
### Code Fixes
**Source code:**
- `TimestampableCacheClearer`: Removed nullable type from property (never assigned null)
- `Configuration`: Added PHPDoc type hints for array parameters/return types
- `EntityConfiguration`: Added PHPDoc type hint for array parameter
- `TimestampableEventSubscriber`: Fixed generic type annotation
**Test code:**
- `Address`, `Organization`: Changed `?int` to `int`, added `@readonly` PHPDoc
- `FunctionalTestCase`: Fixed `method_exists()` call, used `list<>` type
- `MappingTest`: Fixed generic type annotation
- All test classes with `createKernel()`: Added `@param array<string, mixed> $options` PHPDoc