### PR TITLE
[codex] Fix Symfony extension deprecation

### DIFF
--- a/src/DependencyInjection/AndanteTimestampableExtension.php
+++ b/src/DependencyInjection/AndanteTimestampableExtension.php
@@ -14,8 +14,8 @@ use Andante\TimestampableBundle\Timestampable\Registry;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class AndanteTimestampableExtension extends Extension
 {


### PR DESCRIPTION
## Summary
- Replace the HttpKernel Extension base-class import with the DependencyInjection Extension import.
- Keeps the bundle extension API unchanged while avoiding the Symfony 8.1 internal/deprecated class warning.

## Root cause
Symfony 8.1 considers Symfony\Component\HttpKernel\DependencyInjection\Extension internal/deprecated for bundle extensions. The public base class now lives at Symfony\Component\DependencyInjection\Extension\Extension.

## Validation
- php -l src/DependencyInjection/AndanteTimestampableExtension.php
- vendor/bin/phpunit tests/Functional/DependencyInjection/DefaultConfigTest.php
- vendor/bin/phpstan analyse src/DependencyInjection/AndanteTimestampableExtension.php currently stops on existing phpstan.neon options: checkMissingIterableValueType and checkGenericClassInNonGenericObjectType

References https://github.com/andanteproject/timestampable-bundle/issues/12